### PR TITLE
powercap / RAPL: disable the 2nd power limit properly

### DIFF
--- a/drivers/powercap/intel_rapl.c
+++ b/drivers/powercap/intel_rapl.c
@@ -1145,9 +1145,11 @@ static int rapl_unregister_powercap(void)
 			pr_debug("remove package, undo power limit on %d: %s\n",
 				rp->id, rd->name);
 			rapl_write_data_raw(rd, PL1_ENABLE, 0);
-			rapl_write_data_raw(rd, PL2_ENABLE, 0);
 			rapl_write_data_raw(rd, PL1_CLAMP, 0);
-			rapl_write_data_raw(rd, PL2_CLAMP, 0);
+			if (find_nr_power_limit(rd) > 1) {
+				rapl_write_data_raw(rd, PL2_ENABLE, 0);
+				rapl_write_data_raw(rd, PL2_CLAMP, 0);
+			}
 			if (rd->id == RAPL_DOMAIN_PACKAGE) {
 				rd_package = rd;
 				continue;


### PR DESCRIPTION
Let rapl_unregister_powercap() disable the second power limit
only if it exists.
Intel64 SDM Vol.3 14.9 says that the package domain has it
but neither the power plane domain nor the DRAM domain has it.

Signed-off-by: Seiichi Ikarashi s.ikarashi@jp.fujitsu.com
